### PR TITLE
[Documentation] How to run the entire wallet from local node or via npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ interfacing with the Karlsen network.
 ## Get Started
 
 ```sh
-git clone https://github.com/karlsen-network/node-karlsen-core-lib.git
+git clone https://github.com/karlsen-network/node-karlsen-core-lib
 ```
 
 Adding Karlsencore to your app's `package.json`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karlsen/core-lib",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "main": "index.js",
   "authors": [
     {


### PR DESCRIPTION
This is a PR series for all the `node-` packages. Instructions on how to run all of them locally to create web wallet service and how to use published versions in `npm registry` have been added. All the `npm` packages are already available at: https://www.npmjs.com/org/karlsen